### PR TITLE
minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 ## [0.0.1] - TODO: Add release date.
 
 * TODO: Describe initial release.
+
+## [0.0.5] - minor fixes
+
+* added environment variable in pubspec.yaml (to be compatible with latest the flutter version)
+* added ObjC dependency in podspec (in order for the iOS side to work)
+* removed manual BugfenderSDK pod version number override (to pull the latest automatically, currently 1.6.3 instead 1.5.2)

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -26,8 +26,6 @@ target 'Runner' do
     }
   end
 
-  # Bugfender
-  pod 'BugfenderSDK/ObjC', '~> 1.5.2'
 end
 
 post_install do |installer|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -6,7 +6,6 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
-  - Flutter (from `/Users/peter/Developer/flutter-sdk/bin/cache/artifacts/engine/ios`)
   - Flutter (from `/Users/polbatllo/MJ/flutter/bin/cache/artifacts/engine/ios`)
   - flutter_bugfender (from `/Users/polbatllo/MJ/flutter_bugfender/ios`)
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,18 @@
 PODS:
-  - BugfenderSDK/ObjC (1.5.2)
+  - BugfenderSDK/ObjC (1.6.3)
   - Flutter (1.0.0)
-  - flutter_bugfender (0.0.1):
+  - flutter_bugfender (0.0.5):
+    - BugfenderSDK/ObjC
     - Flutter
 
 DEPENDENCIES:
-  - BugfenderSDK/ObjC (~> 1.5.2)
+  - Flutter (from `/Users/peter/Developer/flutter-sdk/bin/cache/artifacts/engine/ios`)
   - Flutter (from `/Users/polbatllo/MJ/flutter/bin/cache/artifacts/engine/ios`)
   - flutter_bugfender (from `/Users/polbatllo/MJ/flutter_bugfender/ios`)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - BugfenderSDK
 
 EXTERNAL SOURCES:
   Flutter:
@@ -16,10 +21,10 @@ EXTERNAL SOURCES:
     :path: /Users/polbatllo/MJ/flutter_bugfender/ios
 
 SPEC CHECKSUMS:
-  BugfenderSDK: dce8c4e14480bece6c14cc7d9e2a0327ba944f4b
-  Flutter: 9d0fac939486c9aba2809b7982dfdbb47a7b0296
-  flutter_bugfender: 49a7bbc762c668335c77957e371dd13446b59679
+  BugfenderSDK: 6f042643b3ae2e67c9a2d2efa7d530d5d8fd399c
+  Flutter: 58dd7d1b27887414a370fcccb9e645c08ffd7a6a
+  flutter_bugfender: 879bd0690d29d22d1799b6e0fa251860b93351df
 
-PODFILE CHECKSUM: 7e4f0ab22065d43de568414173740b4a9a97a3ae
+PODFILE CHECKSUM: a27e5510a5841f36f763f4d8e1b15d813fafa79d
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.6.0

--- a/ios/flutter_bugfender.podspec
+++ b/ios/flutter_bugfender.podspec
@@ -3,10 +3,10 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_bugfender'
-  s.version          = '0.0.1'
+  s.version          = '0.0.5'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
-A new flutter plugin project.
+Flutter plugin to enable Bugfender reporting.
                        DESC
   s.homepage         = 'http://example.com'
   s.license          = { :file => '../LICENSE' }
@@ -15,6 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+  s.dependency 'BugfenderSDK/ObjC'
   
   s.ios.deployment_target = '8.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bugfender
-description: A new flutter plugin project.
-version: 0.0.1
+description: Flutter plugin to enable Bugfender reporting.
+version: 0.0.5
 author:
 homepage:
 
@@ -12,3 +12,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+
+environment:
+  sdk: ">=2.0.0-dev.58.0 <3.0.0"


### PR DESCRIPTION
* added environment variable in `pubspec.yaml` (to be compatible with latest the flutter version)
* added ObjC dependency in `flutter_bugfender.podspec` (in order for the iOS side to work)
* removed manual BugfenderSDK pod version number override (to pull the latest automatically, currently 1.6.3 instead 1.5.2)

should solve #1 