### PR TITLE
Switch order of build.grade repository sources

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,8 +3,8 @@ version '1.2.0'
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {
@@ -14,8 +14,8 @@ buildscript {
 
 rootProject.allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
While recently building an app with a dependency to this repo in CodeMagic I was noticing that the builds were failing on Flutter 2.2.3 with the below errors. After some Googling the issue turned out be  that we needed to swap the order of our dependency repositories in the project build.gradle. Turns out the order matters. Since then builds are now working for Flutter 2.2.3 in CodeMagic.

```
A problem occurred configuring project ':flutter_bugfender'.

> Could not resolve all artifacts for configuration ':flutter_bugfender:classpath'.

   > Could not resolve com.android.tools.lint:lint:26.0.1.

     Required by:

         project :flutter_bugfender > com.android.tools.build:gradle:3.0.1 > com.android.tools.build:gradle-core:3.0.1

      > Could not resolve com.android.tools.lint:lint:26.0.1.

         > Could not get resource 'https://jcenter.bintray.com/com/android/tools/lint/lint/26.0.1/lint-26.0.1.pom'.

            > Could not GET 'https://jcenter.bintray.com/com/android/tools/lint/lint/26.0.1/lint-26.0.1.pom'.

               > Read timed out
...
```