### PR TITLE
Deprecate jcenter and changed the order of repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,8 +3,8 @@ version '1.2.0'
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,8 +14,8 @@ buildscript {
 
 rootProject.allprojects {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {
@@ -11,10 +11,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
This PR change jcenter for mavenCentral as jcenter is already deprecated.

It also set google() repository to be the first one as done in #17 to solve #18 