### PR TITLE
ensure native library is loaded on init, update README, deprecate overrideDeviceName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.2.0]
+* Update: Call `WidgetsFlutterBinding.ensureInitialized()` in the initializer to make sure native plugins are loaded.
+  This makes fewer asumptions on how the plugin is initialized.
+* Update: Deprecate `overrideDeviceName` init parameter
+* Bugfix: Improve installation instructions in README.md
+
 ## [2.1.2]
 * Add support for Gradle 8 builds
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A Bugfender Wrapper plugin (implementing native code) for Flutter Projects.
 
 ## Using the package
 
-Edit `pubspec.yaml` and add add `flutter_bugfender` to `dev_dependencies`:
+Edit `pubspec.yaml` and add add `flutter_bugfender` to `dependencies`:
 
 ```
-dev_dependencies:
-  flutter_test:
+dependencies:
+  flutter:
     sdk: flutter
   flutter_bugfender: ^2.1.2
 ```
@@ -19,26 +19,35 @@ Then run `flutter pub get` (or ‘Packages Get’ in IntelliJ) to download the p
 
 Edit `lib/main.dart` and add an import:
 
-```
+```dart
 import 'package:flutter_bugfender/flutter_bugfender.dart';
 ```
 
-And in your main application builder:
+And wrap your `runApp` statement like this:
 
-```
-await FlutterBugfender.init("YOUR_APP_KEY");
+```dart
+void main() {
+  FlutterBugfender.handleUncaughtErrors(() async {
+    await FlutterBugfender.init("YOUR_APP_KEY",
+        enableCrashReporting: true, // these are optional, but recommended
+        enableUIEventLogging: true,
+        enableAndroidLogcatLogging: true);
+    FlutterBugfender.log("hello world!");
+    runApp(new MyApp());
+  });
+}
 ```
 
 There are other init options:
-* apiUri and baseUri: alternative URLs for on-premises installations
-* maximumLocalStorageSize: maximum size the local log cache will use, in bytes
-* printToConsole: whether to print to console or not
-* enableUIEventLogging: enable automatic logging of user interactions for native elements.
-* enableCrashReporting: enable automatic crash reporting for native crashes. To report Dart exceptions see [this](#report-dart-and-flutter-exceptions).
-* enableAndroidLogcatLogging: enable automatic logging of logcat (Android only)
-* overrideDeviceName: specify a name for the device
-* version: app version identifier (Web specific)
-* build: app build identifier (Web specific)
+* `apiUri` and `baseUri`: alternative URLs for on-premises installations
+* `maximumLocalStorageSize`: maximum size the local log cache will use, in bytes
+* `printToConsole`: whether to print to console or not
+* `enableUIEventLogging`: enable automatic logging of user interactions for native elements.
+* `enableCrashReporting`: enable automatic crash reporting for native crashes. To report Dart exceptions see [this](#report-dart-and-flutter-exceptions).
+* `enableAndroidLogcatLogging`: enable automatic logging of logcat (Android only)
+* `overrideDeviceName`: specify a name for the device (deprecated, prefer `FlutterBugfender.setDeviceString()` instead)
+* `version`: app version identifier (Web specific)
+* `build`: app build identifier (Web specific)
 
 You can also call:
 ```dart
@@ -59,7 +68,7 @@ FlutterBugfender.sendLog(
 );
 FlutterBugfender.setDeviceString("user.email", "example@example.com");
 FlutterBugfender.setDeviceInt("user.id", 32);
-Flu tterBugfender.setDeviceFloat("user.pi", 3.14);
+FlutterBugfender.setDeviceFloat("user.pi", 3.14);
 FlutterBugfender.setDeviceBool("user.enabled", true);
 FlutterBugfender.removeDeviceKey("user.pi");
 FlutterBugfender.sendCrash("Test Crash", "Stacktrace here!");
@@ -73,14 +82,7 @@ FlutterBugfender.getUserFeedback()); // Show a screen which asks for feedback
 ```
 
 ### Report Dart and Flutter Exceptions
-To be able to report flutter exception you'll need to wrap `runApp(new MyApp())` on your main function like this:
-````dart
-FlutterBugfender.handleUncaughtErrors(() async {
-  runApp(new MyApp());
-});
-
-````
-Previous code is just syntactic sugar for the following code that you can use indistinctly if you need more control on error handling:
+If you need more control on error handling, you can replace the call to `handleUncaughtErrors()` with:
 ````dart
 // Capture Flutter Error
 FlutterError.onError = (FlutterErrorDetails details) async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,10 +1,16 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bugfender/flutter_bugfender.dart';
 
 void main() {
   FlutterBugfender.handleUncaughtErrors(() async {
+    await FlutterBugfender.init("<INSERT YOUR BUGFENDER APP KEY>",
+        printToConsole: true,
+        enableCrashReporting: true,
+        enableAndroidLogcatLogging: false,
+        overrideDeviceName: "Anonymous",
+        version: "1.0",
+        build: "555");
+    FlutterBugfender.log("hello world!");
     runApp(new MyApp());
   });
 }
@@ -25,47 +31,35 @@ class _MyAppState extends State<MyApp> {
 
   initPlatformState() async {
     try {
-      await FlutterBugfender.init("<INSERT YOUR BUGFENDER APP KEY>",
-          printToConsole: true,
-          enableCrashReporting: true,
-          enableAndroidLogcatLogging: false,
-          overrideDeviceName: "Anonymous",
-          version: "1.0",
-          build: "555");
-      await FlutterBugfender.log("Working fine!");
-      await FlutterBugfender.fatal("Fatal sent!");
-      await FlutterBugfender.error("Error sent!");
-      await FlutterBugfender.warn("Warning sent!");
-      await FlutterBugfender.info("Info sent!");
-      await FlutterBugfender.debug("Debug sent!");
-      await FlutterBugfender.trace("Trace sent!");
-      await FlutterBugfender.sendLog(
+      FlutterBugfender.log("Working fine!");
+      FlutterBugfender.fatal("Fatal sent!");
+      FlutterBugfender.error("Error sent!");
+      FlutterBugfender.warn("Warning sent!");
+      FlutterBugfender.info("Info sent!");
+      FlutterBugfender.debug("Debug sent!");
+      FlutterBugfender.trace("Trace sent!");
+      FlutterBugfender.sendLog(
           line: 42,
           method: "fakeMethod()",
-          file:"fakeFile.fake",
+          file: "fakeFile.fake",
           level: LogLevel.info,
           tag: "TAG",
-          text: "Custom log 1"
-      );
+          text: "Custom log 1");
 
-      await FlutterBugfender.sendLog(
-          tag: "TAG",
-          text: "Custom log 2"
-      );
-      await FlutterBugfender.setDeviceString(
-          "user.email", "example@example.com");
-      await FlutterBugfender.setDeviceInt("user.id", 1);
-      await FlutterBugfender.setDeviceFloat("user.weight", 1.234);
-      await FlutterBugfender.setDeviceBool("user.team", true);
-      await FlutterBugfender.removeDeviceKey("user.team");
+      FlutterBugfender.sendLog(tag: "TAG", text: "Custom log 2");
+      FlutterBugfender.setDeviceString("user.email", "example@example.com");
+      FlutterBugfender.setDeviceInt("user.id", 1);
+      FlutterBugfender.setDeviceFloat("user.weight", 1.234);
+      FlutterBugfender.setDeviceBool("user.team", true);
+      FlutterBugfender.removeDeviceKey("user.team");
       print(await FlutterBugfender.sendCrash("Test Crash", "Stacktrace here!"));
       print(await FlutterBugfender.sendIssue(
           "Test Issue", "Issue value goes here!"));
       print(await FlutterBugfender.sendUserFeedback(
           "Test user feedback", "User feedback details here!"));
-      await FlutterBugfender.setForceEnabled(true);
-      await FlutterBugfender.setForceEnabled(false);
-      await FlutterBugfender.forceSendOnce();
+      FlutterBugfender.setForceEnabled(true);
+      FlutterBugfender.setForceEnabled(false);
+      FlutterBugfender.forceSendOnce();
       print(await FlutterBugfender.getDeviceUri());
       print(await FlutterBugfender.getSessionUri());
     } catch (e) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,13 +7,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_bugfender:
+    path: ../
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  flutter_bugfender:
-    path: ../
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/lib/flutter_bugfender.dart
+++ b/lib/flutter_bugfender.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
+import 'package:flutter/widgets.dart';
 
-import 'package:flutter/foundation.dart' show FlutterErrorDetails, FlutterError;
 import 'package:flutter_bugfender/flutter_bugfender_interface.dart';
 
 final _flutterBugfenderInterface = FlutterBugfenderInterface.instance;
@@ -23,8 +23,8 @@ class FlutterBugfender {
   ///  - [enableAndroidLogcatLogging] - Logs all logs written via Logcat.
   ///  Defaults to `false`.
   ///  - [overrideDeviceName] - Sets the name for the device. If the Device
-  ///  Name is not set, then the platform standard device name will be
-  ///  automatically sent
+  ///  Name is not set, then the device model will be automatically sent.
+  ///  Deprecated, prefer `FlutterBugfender.setDeviceString()` instead.
   ///  - [version] - App version identifier (Web specific)
   ///  - [build] - App build identifier (Web specific)
   static Future<void> init(
@@ -36,23 +36,26 @@ class FlutterBugfender {
     bool enableUIEventLogging = true,
     bool enableCrashReporting = true,
     bool enableAndroidLogcatLogging = false,
+    @Deprecated('Prefer `setDeviceString()` instead')
     String? overrideDeviceName,
     String? version,
     String? build,
-  }) =>
-      _flutterBugfenderInterface.init(
-        appKey,
-        apiUri: apiUri,
-        baseUri: baseUri,
-        maximumLocalStorageSize: maximumLocalStorageSize,
-        enableAndroidLogcatLogging: enableAndroidLogcatLogging,
-        enableCrashReporting: enableCrashReporting,
-        enableUIEventLogging: enableUIEventLogging,
-        overrideDeviceName: overrideDeviceName,
-        printToConsole: printToConsole,
-        version: version,
-        build: build,
-      );
+  }) {
+    WidgetsFlutterBinding.ensureInitialized();
+    return _flutterBugfenderInterface.init(
+      appKey,
+      apiUri: apiUri,
+      baseUri: baseUri,
+      maximumLocalStorageSize: maximumLocalStorageSize,
+      enableAndroidLogcatLogging: enableAndroidLogcatLogging,
+      enableCrashReporting: enableCrashReporting,
+      enableUIEventLogging: enableUIEventLogging,
+      overrideDeviceName: overrideDeviceName,
+      printToConsole: printToConsole,
+      version: version,
+      build: build,
+    );
+  }
 
   /// Helper method to allow Bugfender to detect uncaught exceptions and
   /// report them.
@@ -128,52 +131,61 @@ class FlutterBugfender {
       _flutterBugfenderInterface.setForceEnabled(enabled);
 
   /// Force enable sending logs and crashes to Bugfender, only for this session
-  static Future<void> forceSendOnce() => _flutterBugfenderInterface.forceSendOnce();
+  static Future<void> forceSendOnce() =>
+      _flutterBugfenderInterface.forceSendOnce();
 
   /// Gets the URL to see the logs of this device
-  static Future<Uri> getDeviceUri() => _flutterBugfenderInterface.getDeviceUri();
+  static Future<Uri> getDeviceUri() =>
+      _flutterBugfenderInterface.getDeviceUri();
 
   /// Gets the URL to see the logs of this session
-  static Future<Uri> getSessionUri() => _flutterBugfenderInterface.getSessionUri();
+  static Future<Uri> getSessionUri() =>
+      _flutterBugfenderInterface.getSessionUri();
 
   /// Send a log. Use this method if you need more control over the data sent
   /// while logging
   static Future<void> sendLog(
-      {int line = 0,
-        String method = "",
-        String file = "",
-        LogLevel level = LogLevel.debug,
-        String tag = "",
-        String text = ""}) =>
+          {int line = 0,
+          String method = "",
+          String file = "",
+          LogLevel level = LogLevel.debug,
+          String tag = "",
+          String text = ""}) =>
       _flutterBugfenderInterface.sendLog(
-        line: line,
-        method: method,
-        file: file,
-        level: level,
-        tag: tag,
-        text: text
-      );
+          line: line,
+          method: method,
+          file: file,
+          level: level,
+          tag: tag,
+          text: text);
 
   /// Log something.
-  static Future<void> log(String value) => _flutterBugfenderInterface.log(value);
+  static Future<void> log(String value) =>
+      _flutterBugfenderInterface.log(value);
 
   /// Send a log with fatal level.
-  static Future<void> fatal(String value) => _flutterBugfenderInterface.fatal(value);
+  static Future<void> fatal(String value) =>
+      _flutterBugfenderInterface.fatal(value);
 
   /// Send a log with error level.
-  static Future<void> error(String value) => _flutterBugfenderInterface.error(value);
+  static Future<void> error(String value) =>
+      _flutterBugfenderInterface.error(value);
 
   /// Send a log with warning level.
-  static Future<void> warn(String value) => _flutterBugfenderInterface.warn(value);
+  static Future<void> warn(String value) =>
+      _flutterBugfenderInterface.warn(value);
 
   /// Send a log with info level.
-  static Future<void> info(String value) => _flutterBugfenderInterface.info(value);
+  static Future<void> info(String value) =>
+      _flutterBugfenderInterface.info(value);
 
   /// Send a log with trace level.
-  static Future<void> trace(String value) => _flutterBugfenderInterface.trace(value);
+  static Future<void> trace(String value) =>
+      _flutterBugfenderInterface.trace(value);
 
   /// Send a log with debug level.
-  static Future<void> debug(String value) => _flutterBugfenderInterface.debug(value);
+  static Future<void> debug(String value) =>
+      _flutterBugfenderInterface.debug(value);
 
   /// Show a screen which asks for feedback.
   /// Once the user closes the modal or sends the feedback the Future promise resolves with the result.

--- a/lib/flutter_bugfender_web.dart
+++ b/lib/flutter_bugfender_web.dart
@@ -1,5 +1,6 @@
 import 'dart:js_util';
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter_bugfender/flutter_bugfender_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -25,6 +26,7 @@ class WebFlutterBugfender extends FlutterBugfenderInterface {
     String? version,
     String? build,
   }) async {
+    WidgetsFlutterBinding.ensureInitialized();
     return promiseToFuture(bugfender_web.init(bugfender_web.Options(
       appKey: appKey,
       apiURL: apiUri?.toString() ?? 'https://api.bugfender.com',


### PR DESCRIPTION
Description:
* Update: Call `WidgetsFlutterBinding.ensureInitialized()` in the initializer to make sure native plugins are loaded.
  This makes fewer asumptions on how the plugin is initialized. (fixes #33)
* Update: Deprecate `overrideDeviceName` init parameter
* Bugfix: Improve installation instructions in README.md

Deployment plan: merge to main
Fallback procedure: revert commit and restore backups if data was lost
Are changes needed in the user's help pages?: included here.
Are changes needed in the on-premises administrator manual?: no
Are changes needed in the disaster recovery plan?: no