### PR TITLE
fix crash when `overrideDeviceName` is missing in web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   This makes fewer asumptions on how the plugin is initialized.
 * Update: Deprecate `overrideDeviceName` init parameter
 * Bugfix: Improve installation instructions in README.md
+* Bugfix: Crash when `overrideDeviceName` was missing in web
 
 ## [2.1.2]
 * Add support for Gradle 8 builds

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Edit `pubspec.yaml` and add add `flutter_bugfender` to `dependencies`:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_bugfender: ^2.1.2
+  flutter_bugfender: ^2.2.0
 ```
 
 Then run `flutter pub get` (or ‘Packages Get’ in IntelliJ) to download the package.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,7 +7,6 @@ void main() {
         printToConsole: true,
         enableCrashReporting: true,
         enableAndroidLogcatLogging: false,
-        overrideDeviceName: "Anonymous",
         version: "1.0",
         build: "555");
     FlutterBugfender.log("hello world!");

--- a/lib/flutter_bugfender_web.dart
+++ b/lib/flutter_bugfender_web.dart
@@ -31,7 +31,7 @@ class WebFlutterBugfender extends FlutterBugfenderInterface {
     WidgetsFlutterBinding.ensureInitialized();
 
     // options keys are variable. For example, the "apiURL" key may or may not be present.
-    // We can't use Dart classes with automatic converstion because Dart properties of a class are null when unset, but Bugfender.init() expects undefined.
+    // We can't use Dart classes with automatic conversion because Dart properties of a class are null when unset, but Bugfender.init() expects undefined.
     var options = {
       'appKey': appKey,
       'overrideConsoleMethods': false,

--- a/lib/flutter_bugfender_web.dart
+++ b/lib/flutter_bugfender_web.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:js';
 import 'dart:js_util';
 
 import 'package:flutter/widgets.dart';
@@ -17,7 +19,7 @@ class WebFlutterBugfender extends FlutterBugfenderInterface {
     String appKey, {
     Uri? apiUri,
     Uri? baseUri,
-    int? maximumLocalStorageSize,
+    int? maximumLocalStorageSize, // note this is ignored in web
     bool printToConsole = true,
     bool enableUIEventLogging = true,
     bool enableCrashReporting = true,
@@ -27,19 +29,44 @@ class WebFlutterBugfender extends FlutterBugfenderInterface {
     String? build,
   }) async {
     WidgetsFlutterBinding.ensureInitialized();
-    return promiseToFuture(bugfender_web.init(bugfender_web.Options(
-      appKey: appKey,
-      apiURL: apiUri?.toString() ?? 'https://api.bugfender.com',
-      baseURL: baseUri?.toString() ?? 'https://dashboard.bugfender.com',
-      overrideConsoleMethods: false,
-      printToConsole: printToConsole,
-      registerErrorHandler: enableCrashReporting,
-      logBrowserEvents: enableUIEventLogging,
-      logUIEvents: enableUIEventLogging,
-      deviceName: overrideDeviceName,
-      version: version ?? '',
-      build: build ?? '',
-    )));
+
+    // options keys are variable. For example, the "apiURL" key may or may not be present.
+    // We can't use Dart classes with automatic converstion because Dart properties of a class are null when unset, but Bugfender.init() expects undefined.
+    var options = {
+      'appKey': appKey,
+      'overrideConsoleMethods': false,
+      'printToConsole': printToConsole,
+      'registerErrorHandler': enableCrashReporting,
+      'logBrowserEvents': enableUIEventLogging,
+      'logUIEvents': enableUIEventLogging,
+    };
+    if (apiUri != null) {
+      options['apiURL'] = apiUri.toString();
+    }
+    if (baseUri != null) {
+      options['baseURL'] = baseUri.toString();
+    }
+    if (overrideDeviceName != null) {
+      options['deviceName'] = overrideDeviceName;
+    }
+    if (version != null) {
+      options['version'] = version;
+    }
+    if (build != null) {
+      options['build'] = build;
+    }
+
+    // call Bugfender.init(options)
+    JsObject jsPromise =
+        context['Bugfender'].callMethod('init', [JsObject.jsify(options)]);
+
+    // convert the JS Promise to a Dart Future
+    final completer = new Completer<void>();
+    jsPromise.callMethod('then', [
+      allowInterop(completer.complete),
+      allowInterop(completer.completeError)
+    ]);
+    return completer.future;
   }
 
   @override

--- a/lib/js_bugfender.dart
+++ b/lib/js_bugfender.dart
@@ -3,10 +3,7 @@ library bugfender;
 
 import 'package:js/js.dart';
 
-@JS('Bugfender.init')
-external Object init(Options options);
-// Returning Object instead of void to be able to make use of promiseToFuture
-// on flutter_bugfender_web.dart
+// init: proxying and automatic conversion doesn't work because the options object can have a variable number of keys
 
 @JS('Bugfender.setDeviceKey')
 external void setDeviceKey(String key, dynamic value);
@@ -57,7 +54,8 @@ external void fatal(String log);
 external void forceSendOnce();
 
 @JS('Bugfender.getUserFeedback')
-external UserFeedbackResult getUserFeedback(UserFeedbackOptions userFeedbackOptions);
+external UserFeedbackResult getUserFeedback(
+    UserFeedbackOptions userFeedbackOptions);
 
 @JS()
 @anonymous
@@ -90,7 +88,7 @@ class LogEntry {
 @JS()
 @anonymous
 class UserFeedbackOptions {
-  external String? get  title;
+  external String? get title;
   external String? get hint;
   external String? get subjectPlaceholder;
   external String? get feedbackPlaceholder;
@@ -109,44 +107,4 @@ class UserFeedbackOptions {
 class UserFeedbackResult {
   external bool get isSent;
   external String? get feedbackURL;
-}
-
-@JS()
-@anonymous
-class Options {
-  external String get appKey;
-
-  external String? get apiURL;
-
-  external String? get baseURL;
-
-  external String? get deviceName;
-
-  external bool get overrideConsoleMethods;
-
-  external bool get printToConsole;
-
-  external bool get registerErrorHandler;
-
-  external bool get logBrowserEvents;
-
-  external bool get logUIEvents;
-
-  external String? get version;
-
-  external String? get build;
-
-  external factory Options({
-    String appKey,
-    String? apiURL,
-    String? baseURL,
-    bool overrideConsoleMethods,
-    bool printToConsole,
-    bool registerErrorHandler,
-    bool logBrowserEvents,
-    bool logUIEvents,
-    String? deviceName,
-    String? version,
-    String? build,
-  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_bugfender
 description: Flutter plugin to enable Bugfender reporting (iOS, Android and web support).
-version: 2.1.2
+version: 2.2.0
 homepage: https://bugfender.com
 repository: https://github.com/bugfender/BugfenderSDK-Flutter
 


### PR DESCRIPTION
Description:
* Use the lower-level JsObject API instead of automatically-converted classes to call `Bugfender.init()` because the options object doesn't always have the same keys.

Deployment plan: merge to main
Fallback procedure: revert commit and restore backups if data was lost
Are changes needed in the user's help pages?: no
Are changes needed in the on-premises administrator manual?: no
Are changes needed in the disaster recovery plan?: no